### PR TITLE
add rm diag_integral.out to test script

### DIFF
--- a/test_fms/diag_integral/test_diag_integral2.sh
+++ b/test_fms/diag_integral/test_diag_integral2.sh
@@ -34,6 +34,6 @@ test_expect_success "test_diag_integral r8" 'mpirun -n 1 ./test_diag_integral_r8
 
 rm input.nml
 rm -rf INPUT
-
+rm diag_integral.out
 
 test_done


### PR DESCRIPTION
This PR adds the line `rm diag_integral.out` in test_fms/diag_integral/test_diag_integral2.sh