### PR TITLE
rm diag_integral.out twice

### DIFF
--- a/test_fms/diag_integral/test_diag_integral2.sh
+++ b/test_fms/diag_integral/test_diag_integral2.sh
@@ -30,10 +30,11 @@ EOF
 mkdir -p INPUT
 
 test_expect_success "test_diag_integral r4" 'mpirun -n 1 ./test_diag_integral_r4'
+rm diag_integral.out
 test_expect_success "test_diag_integral r8" 'mpirun -n 1 ./test_diag_integral_r8'
+rm diag_integral.out
 
 rm input.nml
 rm -rf INPUT
-rm diag_integral.out
 
 test_done


### PR DESCRIPTION
This PR removes diag_integral.out after the r4 test and a fter the r8 test.