### PR TITLE
fix for doxygen action

### DIFF
--- a/.github/workflows/github_doc_site.yml
+++ b/.github/workflows/github_doc_site.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
**Description**
Updates the action to specify the older ubuntu image (see #1664 for details). This is more of a short term fix, I will put in more updates eventually for the doxyfile to work with the latest doxygen versions.

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

